### PR TITLE
Pull apart long ugly commandlines for fetching Firefox source.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,2 @@
-/mozilla-aurora-*.tar.bz2
+/firefox-*.tar.bz2
 /firefox-langpacks*
-
-.*.sw*

--- a/GET_SOURCE.bash
+++ b/GET_SOURCE.bash
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# Get the source code for the latest Firefox Aurora release.
+export VERSION=$(grep -P "^Version:" firefox-dev.spec | grep -Po "[0-9\.a]{6}")
+export LATEST_COMMIT=$(basename $(curl "https://archive.mozilla.org/pub/firefox/nightly/latest-mozilla-aurora/firefox-$VERSION.en-US.linux-x86_64.txt" | tail -n1))
+echo
+echo "*** Downloading latest release of Firefox Aurora..."
+curl -O "https://hg.mozilla.org/releases/mozilla-aurora/archive/$LATEST_COMMIT.tar.bz2"
+mv $LATEST_COMMIT.tar.bz2 firefox-$VERSION.tar.bz2
+
+# Get the langpacks too.
+export LANGPACK_URL="https://archive.mozilla.org/pub/firefox/nightly/latest-mozilla-aurora-l10n/linux-x86_64/xpi/"
+mkdir -p firefox-langpacks
+cd firefox-langpacks
+echo
+echo "*** Downloading langpacks for Firefox..."
+curl $LANGPACK_URL | egrep -o "\".*?firefox-$VERSION.*?\.xpi\"" | sed 's/"//g' | awk "{print \"https://archive.mozilla.org\" \$0}" | xargs wget
+echo
+echo "*** Repacking language files..."
+for f in *
+	do mv $f $(echo $f | awk 'match($0, /firefox-.*?\.(.*?)\.langpack.xpi/, a){print a[1] ".xpi"}')
+done
+cd ..
+tar -cvf - firefox-langpacks | xz -zc - > firefox-langpacks-$VERSION.tar.xz
+rm -rf firefox-langpacks
+
+echo
+echo "*** All finished!"

--- a/README.md
+++ b/README.md
@@ -1,40 +1,69 @@
 firefox-dev
 ===========
 
-This is a fork of http://pkgs.fedoraproject.org/cgit/firefox.git/
-tracking Mozilla's Aurora release channel, otherwise known as [Firefox
-Developer Edition](https://www.mozilla.org/firefox/developer/).
+This is a fork of
+[the Fedora packaging repo for mainline Firefox](http://pkgs.fedoraproject.org/cgit/firefox.git/),
+tracking Mozilla's Aurora release channel, otherwise known as
+[Firefox Developer Edition](https://www.mozilla.org/firefox/developer/).
 
-### Getting the goods
 
-Fetch it from Copr while it's hot!
 
-```
-dnf copr enable bob131/firefox-dev
-dnf install firefox-dev
-```
+## How to install
 
-Be warned: This package obsoletes the firefox package; both packages
+Those interested in helping test this build of Firefox Developer Edition can
+see the instructions below about building from spec. Otherwise, just add the
+Copr repository.
+
+Be warned, though: This package obsoletes the firefox package. Both packages
 can't be installed on the same system simultaneously.
+
+
+### Copr makes it easy
+
+``` bash
+sudo dnf copr enable bob131/firefox-dev
+sudo dnf install firefox-dev
+```
+
 
 ### Building from spec
 
-This assumes an empty or absent `~/rpmbuild` directory.
+First, a little setup: Obviously, you need a copy of this repository.
 
+``` bash
+git clone https://github.com/Bob131/firefox-dev.git
+cd firefox-dev
 ```
-hub clone Bob131/firefox-dev && cd firefox-dev
-export VER="`grep -P "^Version:" firefox-dev.spec | grep -Po "[0-9\.a]{6}"`"
-curl -O "https://hg.mozilla.org/releases/mozilla-aurora/archive/$(basename `curl https://archive.mozilla.org/pub/firefox/nightly/latest-mozilla-aurora/firefox-$VER.en-US.linux-x86_64.txt | tail -n1`).tar.bz2" && ls *.tar.bz2 | xargs -I {} mv {} mozilla-aurora-{}
-export URL="https://archive.mozilla.org/pub/firefox/nightly/latest-mozilla-aurora-l10n/linux-x86_64/xpi/" && mkdir firefox-langpacks; cd firefox-langpacks && curl $URL | egrep -o "\".*?firefox-$VER.*?\.xpi\"" | sed 's/"//g' | awk "{print \"https://archive.mozilla.org\" \$0}" | xargs wget && for f in *; do mv $f `echo $f | awk 'match($0, /firefox-.*?\.(.*?)\.langpack.xpi/, a){print a[1] ".xpi"}'`; done; cd .. && tar -cvf - firefox-langpacks | xz -zc - > firefox-langpacks-$VER.tar.xz && rm -rf firefox-langpacks
-mkdir ~/rpmbuild
-ln -s `pwd` ~/rpmbuild/SOURCES
-rpmbuild -ba firefox-dev.spec
+
+Then, to fetch the source code for the latest release of Firefox Developer
+Edition, we have a convenient script:
+
+``` bash
+./GET_SOURCE.bash
 ```
+
+And finally you can build the actual package.
+
+``` bash
+rpmbuild --define "%_sourcedir $(pwd)" -ba firefox-dev.spec
+```
+
+Getting updates for our packaging repo is easy:
+
+``` bash
+git pull origin master
+```
+
+And then if there's a new release, you download the latest Firefox source
+again.
+
+
 
 ## Frequently Asked Questions
 
 (also known as "questions that have never been asked but the author felt
 needed answering anyway")
+
 
 ### Aurora refuses to use my preexisting Firefox profile! What do?
 
@@ -44,11 +73,13 @@ This should do the trick:
 touch ~/.mozilla/firefox/ignore-dev-edition-profile
 ```
 
+
 ### Why the `-dev` suffix instead of the usual `-devel`?
 
 I'm far from an expert on these matters, but personally I would expect
 packages with the `-devel` suffix to contain actual library headers and
 whatnot. This package includes no such thing.
+
 
 ### What license is this repo under?
 

--- a/firefox-dev.spec
+++ b/firefox-dev.spec
@@ -88,19 +88,20 @@
 
 Summary:        Developer Edition (Aurora release channel) of the Mozilla Firefox Web browser
 Name:           firefox-dev
-Version:        44.0a2
-Release:        %(date +%%Y%%m%%d)hg%{rev}%{?dist}
+# You can see which is the latest version here:
+# https://archive.mozilla.org/pub/firefox/nightly/latest-mozilla-aurora/
+Version:        45.0a2
+Release:        %(date +%%Y.%%m.%%d)hg%{rev}%{?dist}
 URL:            https://www.mozilla.org/firefox/developer/
 License:        MPLv1.1 or GPLv2+ or LGPLv2+
 Group:          Applications/Internet
-                # Fetch source with
-                # curl -O "https://hg.mozilla.org/releases/mozilla-aurora/archive/$(basename `curl https://archive.mozilla.org/pub/firefox/nightly/latest-mozilla-aurora/firefox-41.0a2.en-US.linux-x86_64.txt | tail -n1`).tar.bz2"
-Source0:        mozilla-aurora-%{rev}.tar.bz2
+
+Source0:        firefox-%{version}.tar.bz2
+
 %if %{build_langpacks}
-                # Fetch/build with this lovely one-liner (remember to sub version numbers):
-                # export URL="https://archive.mozilla.org/pub/firefox/nightly/latest-mozilla-aurora-l10n/linux-x86_64/xpi/" && mkdir firefox-langpacks; cd firefox-langpacks && curl $URL | egrep -o "\".*?firefox-$VER.*?\.xpi\"" | sed 's/"//g' | awk "{print \"https://archive.mozilla.org\" \$0}" | xargs wget && for f in *; do mv $f `echo $f | awk 'match($0, /firefox-.*?\.(.*?)\.langpack.xpi/, a){print a[1] ".xpi"}'`; done; cd .. && tar -cvf - firefox-langpacks | xz -zc - > firefox-langpacks-$VER.tar.xz && rm -rf firefox-langpacks
 Source1:        firefox-langpacks-%{version}.tar.xz
 %endif
+
 Source10:       firefox-mozconfig
 Source12:       firefox-redhat-default-prefs.js
 Source20:       firefox.desktop
@@ -154,6 +155,7 @@ BuildRequires:  pkgconfig(libIDL-2.0)
 %if %{toolkit_gtk3}
 BuildRequires:  pkgconfig(gtk+-3.0)
 %endif
+
 BuildRequires:  pkgconfig(gtk+-2.0)
 BuildRequires:  pkgconfig(krb5)
 BuildRequires:  pkgconfig(pango)
@@ -172,7 +174,6 @@ BuildRequires:  pkgconfig(libpulse)
 BuildRequires:  pkgconfig(icu-i18n)
 BuildRequires:  pkgconfig(gconf-2.0)
 BuildRequires:  yasm
-
 BuildRequires:  ImageMagick
 BuildRequires:  GConf2-devel
 
@@ -209,7 +210,7 @@ Provides:       webclient
 
 %description
 Mozilla Firefox is an open-source web browser, designed for standards
-compliance, performance and portability.
+compliance, performance, and portability.
 
 %if %{enable_mozilla_crashreporter}
 %global moz_debug_prefix %{_prefix}/lib/debug


### PR DESCRIPTION
The suggestion in README to symlink the rpmbuild SOURCES directory to this
repo's working directory seemed unnecessarily complicated to me, and interfered
with users who are building more than one application from spec. Adding a
`--define ...` parameter to the `rpmbuild` commandline is much simpler.

I also moved all bash commands for fetching Firefox source code into a script,
and reformatted everything for readability.